### PR TITLE
#146 Rolled back numpy to 1.16.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     ],
     install_requires=[
         'click',
-        'numpy==1.19.3',
+        'numpy==1.16.5',
         'scipy',
         'matplotlib',
         'tqdm'


### PR DESCRIPTION
All tests pass for python 3.6 and 3.8